### PR TITLE
DTSCCI-5716: Guarantee unique perf-test users (avoid shared-draft concurrency)

### DIFF
--- a/src/gatling/simulations/uk/gov/hmcts/reform/civildamage/performance/scenarios/CreateUser.scala
+++ b/src/gatling/simulations/uk/gov/hmcts/reform/civildamage/performance/scenarios/CreateUser.scala
@@ -10,14 +10,21 @@ object CreateUser {
 
   val IdamAPIURL = Environment.idamAPIURL
 
+  // Guaranteed-unique per virtual user. A 5-char random suffix (52^5) collides as accounts
+  // accumulate across nightly runs, so two VUs can be minted the same email: the second gets a
+  // 409 from IDAM and both journeys end up on the SAME claimant account, whose single draft
+  // (keyed by userId in civil-citizen-ui) they then submit concurrently -> the shared-draft race
+  // (DTSCCI-5716). A UUID removes any collision, so every VU has its own account and draft.
+  private def uniqueSuffix() = java.util.UUID.randomUUID().toString.replace("-", "")
+
   val newUserFeeder = Iterator.continually(Map(
-    "claimantEmailAddress" -> ("cuiimtclaimantuser" + Common.randomString(5) + "@gmail.com"),
+    "claimantEmailAddress" -> ("cuiimtclaimantuser" + uniqueSuffix() + "@gmail.com"),
     "password" -> "Password12!",
     "role" -> "citizen"
   ))
-  
+
   val newUserFeederDef = Iterator.continually(Map(
-    "defEmailAddress" -> ("cuiimtdefuser" + Common.randomString(5) + "@gmail.com"),
+    "defEmailAddress" -> ("cuiimtdefuser" + uniqueSuffix() + "@gmail.com"),
     "password" -> "Password12!",
     "role" -> "citizen"
   ))


### PR DESCRIPTION
## Problem
Under load, multiple virtual users end up on the **same claimant account**, so they race on **one** civil-citizen-ui claim draft (the draft store is keyed by `userId`): the first submits and deletes it; the stragglers hit a deleted/empty draft. In **civil-citizen-ui** that produced `Case not found` and `Cannot read properties of undefined (helpWithFees)` 500s at check-and-send (now redirected by civil-citizen-ui PR #7833), and in the perf run it shows as a **text-check KO** for those users (they never see "Claim submitted"). Root cause is documented in **DTSCCI-5716** / **DTSCCI-5714**.

## Why VUs share an account
`CreateUser` mints emails with a **5-char random suffix**:
```scala
"cuiimtclaimantuser" + Common.randomString(5) + "@gmail.com"   // 52^5, letters only
```
IDAM accounts are never cleaned up, so across months of nightly runs the used-email space fills and **collisions occur**. When two VUs generate the same email, the second gets a **409** from IDAM (`status.is(201)` KO) and both journeys proceed against the **same pre-existing account** → shared draft → the race.

The `409`s are already visible in recent runs (`CUIR2_Claimant_CreateCitizen: status.find.is(201), found 409`).

## Fix
Use a **UUID** suffix — globally unique, zero collision — so every VU gets its own account and its own draft, removing the race at source:
```scala
private def uniqueSuffix() = java.util.UUID.randomUUID().toString.replace("-", "")
...
"cuiimtclaimantuser" + uniqueSuffix() + "@gmail.com"
```
Applied to both claimant and defendant feeders.

## Notes
- Minimal, low-risk change; no scenario/injection changes.
- Complements civil-citizen-ui **PR #7833** (which makes the app graceful when the race does occur). This PR prevents the race from being manufactured in the first place, so those users complete their submission and the text checks pass.